### PR TITLE
Fix typos, formatting issues across spec docs

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -71,7 +71,7 @@ To ensure these checks are also run in the local repository while making changes
 pip3 install pre-commit && pre-commit install
 ----
 
-When enabling additional checks https://pre-commit.com/#plugins[by editing .pre-commit-config.yaml], it is recommended to run to newly added check on all files in the repository. This can be done with the following command:
+When enabling additional checks https://pre-commit.com/#plugins[by editing .pre-commit-config.yaml], it is recommended to run the newly added check on all files in the repository. This can be done with the following command:
 [source,shell]
 ----
 pre-commit run --all-files

--- a/src/server_soc.bib
+++ b/src/server_soc.bib
@@ -49,7 +49,7 @@
 }
 @electronic{IOMMU,
   title = {RISC-V IOMMU Architecture Specification},
-  url = { https://github.com/riscv-non-isa/riscv-iommu}
+  url = {https://github.com/riscv-non-isa/riscv-iommu}
 }
 @electronic{QOS,
   title = {RISC-V Capacity and Bandwidth Controller QoS Register Interface},

--- a/src/server_soc_intro.adoc
+++ b/src/server_soc_intro.adoc
@@ -194,7 +194,7 @@ if they are not in this table).
 | PMA              | Physical Memory Attributes.
 | PMP              | Physical Memory Protection.
 | Significant Cache| A large cache that might have significant impact on
-                     performance. This specification recommendeds that a cache
+                     performance. This specification recommends that a cache
                      with a capacity larger than 32 KiB be considered a
                      significant cache if it has a significant impact on
                      performance.
@@ -202,7 +202,7 @@ if they are not in this table).
 | SoC              | System on a chip, also referred as system-on-a-chip and
                      system-on-chip.
 | SPA              | Supervisor Physical Address: Physical address used to
-                     to access memory and memory-mapped resources.
+                     access memory and memory-mapped resources.
 | SPDM             | Follows DMTF Standard. Security Protocols and Data Models.
                      A standard for authentication, attestation and key exchange
                      to assist in providing infrastructure security enablement.

--- a/src/server_soc_requirements.adoc
+++ b/src/server_soc_requirements.adoc
@@ -263,7 +263,7 @@ deliver external interrupts to the RISC-V application processor harts.
      bridge the IOMMU may need to access in-memory data structures such as the
      device directory table and page tables.                                   +
                                                                                +
-     The physical memory protection limit access from IOMMUs to phusical
+     The physical memory protection limit access from IOMMUs to physical
      addresses to support secure processing and contain faults. These checks
      allow restricting the IOMMU to only have access to the same memory that
      the hart software that programs the IOMMU has access to.                  +
@@ -376,7 +376,7 @@ translate the IOVA to Supervisor Physical Addresses (SPA).
 [%header, cols="5,25"]
 |===
 | RCI_010  | The PCIe root ports, host bridges, RCRBs, and RCECs in the root
-             compplex MUST implement all software visible rules defined by the
+             complex MUST implement all software visible rules defined by the
              PCIe specification 6.0 for the root complex as applicable.
 |===
 
@@ -758,7 +758,7 @@ messages or completions.
      VDMs such as those carrying MCTP protocol messages enables greater system
      design flexibility in supporting these management protocols._
 
-| IDR_030  | P2P routing of PCIe VDM to/from RCIeP MAY be supported.
+| IDR_030  | P2P routing of PCIe VDM to/from RCiEP MAY be supported.
 
 |===
 
@@ -1102,7 +1102,7 @@ mechanism in PCIe.
 2+| _Configurable enables provide software with the flexibility of using an
      event-based or polling-based error logging for both corrected errors and
      deferred errors. Typically, software operates in an event-based mode for
-     critical errors, as these errors necessiate immediate remedial action when
+     critical errors, as these errors necessitate immediate remedial action when
      they arise._
 
 | RAS_060  | If RERI is supported, RAS error records MUST preserve the

--- a/src/server_soc_tests.adoc
+++ b/src/server_soc_tests.adoc
@@ -92,7 +92,7 @@
 [%header, cols="8,25"]
 |===
 | ID#            ^| Algorithm
-| ME_IOM_010_010 a| . Locate all IOMMUs reported by APCI and verify they are of
+| ME_IOM_010_010 a| . Locate all IOMMUs reported by ACPI and verify they are of
                       RIMT type.
                     . For each IOMMU, read the `capabilities` register and
                       verify that it supports version 1.0 of the RISC-V IOMMU
@@ -196,7 +196,7 @@
 [%header, cols="8,25"]
 |===
 | ID#            ^| Algorithm
-| MF_ECM_010_010 a| . Parse ACPI MCFG tables to local all ECAM ranges.
+| MF_ECM_010_010 a| . Parse ACPI MCFG tables to locate all ECAM ranges.
                     . For each 4 KiB range in the ECAM range, verify that the
                       following reads do not cause any errors or exceptions.
                       .. 4-bytes at offset 0 - vendor and device ID
@@ -211,11 +211,11 @@
                     . Capture timestamp B from `time` CSR.
                     . Verify that the two timestamps are at least 1000 ns apart.
 | MF_ECM_030_010 a| . Parse ACPI MCFG table and obtain ECAM ranges for all
-                      heirarchies.
+                      hierarchies.
                     . Verify that the ECAM ranges for each hierarchy are all
-                      contigous and the base address is naturally aligned to
+                      contiguous and the base address is naturally aligned to
                       the size.
-                    . Verify ranges of any two heirarchies do not overlap.
+                    . Verify ranges of any two hierarchies do not overlap.
 | MF_ECM_040_010 a| See MF_ECM_030_010.
 | MF_ECM_050_010 a| TBA.
 | MF_ECM_060_010 a| . This test requires an input parameter that indicates
@@ -539,7 +539,7 @@ mechanism in PCIe.
 | ID#            ^| Algorithm
 | MF_VSR_010_010 a| . Use PCIe discovery to locate all RCiEP, root ports, IOMMUs,
                       and host bridges.
-                    . For each dicovered function walk the PCIe capability list
+                    . For each discovered function walk the PCIe capability list
                       and verify that the capability ID is one of PCIe specified
                       capabilities.
 | MF_VSR_020_010 a| No tests.
@@ -610,7 +610,7 @@ No tests are defined for these requirements.
                     IOMMU in the test output log.
 | OE_QOS_050_010 a| If ACPI RQSC table is not present then this test is skipped.
 
-                    . Determine caches in the Soc from the ACPI PPTT table.
+                    . Determine caches in the SoC from the ACPI PPTT table.
                     . Determine if there is a capacity controller implemented by
                       that cache by looking up the cache ID in ACPI RQSC table
                       and report in test output log whether capacity allocation
@@ -663,7 +663,7 @@ These tests require the use of a vendor provided API to access the HPMs.
 [%header, cols="8,25"]
 |===
 | ID#            ^| Algorithm
-| OF_SPM_010_010 a| . Determine caches in the Soc from the ACPI PPTT table and
+| OF_SPM_010_010 a| . Determine caches in the SoC from the ACPI PPTT table and
                       obtain their cache IDs.
                     . Allocate two regions of memory.
                     . For each data cache:

--- a/src/server_soc_ts_intro.adoc
+++ b/src/server_soc_ts_intro.adoc
@@ -161,7 +161,7 @@ if they are not in this table).
 | SoC              | System on a chip, also referred as system-on-a-chip and
                      system-on-chip.
 | SPA              | Supervisor Physical Address: Physical address used to
-                     to access memory and memory-mapped resources.
+                     access memory and memory-mapped resources.
 | SPDM             | Follows DMTF Standard. Security Protocols and Data Models.
                      A standard for authentication, attestation and key exchange
                      to assist in providing infrastructure security enablement.


### PR DESCRIPTION
  - Fix spelling errors: recommendeds, phusical, compplex, necessiate,
    contigous, heirarchies, dicovered, APCI
  - Fix duplicated word "to to" in SPA glossary definition (both specs)
  - Fix incorrect capitalization: RCIeP -> RCiEP, Soc -> SoC
  - Fix "to local" -> "to locate" in test spec
  - Fix grammar "run to newly added check" -> "run the newly added check"
  - Fix leading whitespace in server_soc.bib entries (IOMMU url)